### PR TITLE
Updates for PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "deliciousbrains/wp-testimonials",
   "description": "WordPress must-use plugin for managing testimonials, importing from tweets and displaying them.",
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "authors": [
     {
       "name": "Delicious Brains",
@@ -11,14 +11,18 @@
   ],
   "type": "wordpress-muplugin",
   "require": {
-    "abraham/twitteroauth": "^1.0",
-    "composer/installers": "~1.0",
-    "deliciousbrains/wp-post-types": "^1.0",
-    "boxuk/wp-muplugin-loader": "^1.2"
+    "abraham/twitteroauth": "^7.0",
+    "composer/installers": "^2.3",
+    "deliciousbrains/wp-post-types": "^1.0"
   },
   "autoload": {
     "psr-4": {
       "DeliciousBrains\\WPTestimonials\\": "src/"
+    }
+  },
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,8 @@
       "composer/installers": true,
       "boxuk/wp-muplugin-loader": true
     }
+  },
+  "extra": {
+    "mu-require-file": false
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
   "type": "wordpress-muplugin",
   "require": {
     "abraham/twitteroauth": "^7.0",
+    "boxuk/wp-muplugin-loader": "^2.0",
     "composer/installers": "^2.3",
     "deliciousbrains/wp-post-types": "^1.0"
   },
@@ -22,7 +23,8 @@
   },
   "config": {
     "allow-plugins": {
-      "composer/installers": true
+      "composer/installers": true,
+      "boxuk/wp-muplugin-loader": true
     }
   }
 }


### PR DESCRIPTION
- Update valid license from `GPL-2.0+` to `GPL-2.0-or-later`
- Update dependencies to latest
- Allow `composer/installers` and `boxuk/wp-muplugin-loader`

## Testing instructions

On PHP 8.2+

1. Check for valid `composer.json` with `composer validate`
2. Lint all files with PHP 8 `find . -type f -name "*.php" ! -path "*/vendor/*" -exec php -l {} \; | grep -v "No syntax errors" || true`

Drop this in your `composer.json`, run `composer install` and it should put `wp-content/mu-plugins/wp-testimonials/` with `wp-content/mu-plugins/mu-loader.php` (generated by `boxuk/wp-muplugin-loader`)

```json
{
    "name": "fun-composer/project",
    "type": "project",
    "repositories": [
        {
            "type": "composer",
            "url": "https://wpackagist.org"
        }
    ],
    "require": {
        "deliciousbrains/wp-testimonials": "dev-php8-updates as dev-master"
    },
    "config": {
        "allow-plugins": {
            "boxuk/wp-muplugin-loader": true,
            "composer/installers": true
        }
    },
    "extra": {
        "installer-paths": {
          "wp-content/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
          "wp-content/plugins/{$name}/": ["type:wordpress-plugin"],
          "wp-content/themes/{$name}/": ["type:wordpress-theme"]
        }
    }
}
```