### PR TITLE
Use newly tagged wp-post-types 1.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "abraham/twitteroauth": "^7.0",
     "boxuk/wp-muplugin-loader": "^2.0",
     "composer/installers": "^2.3",
-    "deliciousbrains/wp-post-types": "^1.0"
+    "deliciousbrains/wp-post-types": "^1.1.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
I tagged a new release for `deliciousbrains/wp-post-types` and this updates Testimonials to use the latest.